### PR TITLE
Require from relative path

### DIFF
--- a/src/barista
+++ b/src/barista
@@ -1,6 +1,8 @@
-REQUIRE_ROOT=$(dirname $BASH_SOURCE)
-require() {
-  source ${REQUIRE_ROOT}/$1
+shopt -s expand_aliases
+
+alias require='require_from $(dirname $BASH_SOURCE)'
+require_from() {
+  source $1/$2
 }
 
 require 'core/helper.sh'

--- a/src/platforms/arch.sh
+++ b/src/platforms/arch.sh
@@ -1,2 +1,2 @@
-require 'platforms/service/systemd.sh'
-require 'platforms/package/pacman.sh'
+require 'service/systemd.sh'
+require 'package/pacman.sh'

--- a/src/platforms/redhat5.sh
+++ b/src/platforms/redhat5.sh
@@ -1,2 +1,2 @@
-require 'platforms/service/init.sh'
-require 'platforms/package/yum.sh'
+require 'service/init.sh'
+require 'package/yum.sh'

--- a/src/platforms/redhat7.sh
+++ b/src/platforms/redhat7.sh
@@ -1,2 +1,2 @@
-require 'platforms/service/systemd.sh'
-require 'platforms/package/yum.sh'
+require 'service/systemd.sh'
+require 'package/yum.sh'


### PR DESCRIPTION
Change require command as load a file from relative path, because bash has no require path such as ruby.